### PR TITLE
fix(routes): Go to user profile from following or followers not working

### DIFF
--- a/lib/features/home/widget/upload_story_options_dialog.dart
+++ b/lib/features/home/widget/upload_story_options_dialog.dart
@@ -49,7 +49,7 @@ class UploadStoryOptionsDialog extends StatelessWidget {
 
                 if (context.mounted && image != null) {
                   context.pop();
-                  parentContext.push(Paths.uploadStory.route, extra: image);
+                  parentContext.pushNamed(Paths.uploadStory.name, extra: image);
                 }
               },
             ),
@@ -61,7 +61,7 @@ class UploadStoryOptionsDialog extends StatelessWidget {
 
                 if (context.mounted && image != null) {
                   context.pop();
-                  parentContext.push(Paths.uploadStory.route, extra: image);
+                  parentContext.pushNamed(Paths.uploadStory.name, extra: image);
                 }
               },
             ),
@@ -75,7 +75,10 @@ class UploadStoryOptionsDialog extends StatelessWidget {
                   (image) {
                     if (context.mounted) {
                       context.pop();
-                      parentContext.push(Paths.uploadStory.route, extra: image);
+                      parentContext.pushNamed(
+                        Paths.uploadStory.name,
+                        extra: image,
+                      );
                     }
                   },
                   (error, __) {

--- a/lib/features/login/login_mobile_layout.dart
+++ b/lib/features/login/login_mobile_layout.dart
@@ -60,14 +60,15 @@ class _RegisterMobileLayoutState extends ConsumerState<LoginMobileLayout> {
                 padding: const EdgeInsets.only(top: AppDimens.m),
                 child: PrimaryLink(
                   text: l10n.are_you_not_registered_question,
-                  onTap: () => context.push(Paths.register.route),
+                  onTap: () => context.pushNamed(Paths.register.name),
                 ),
               ),
               Padding(
                 padding: const EdgeInsets.only(top: AppDimens.m),
                 child: PrimaryLink(
                   text: l10n.does_not_remember_your_password,
-                  onTap: () => context.push(Paths.resetPasswordRequest.route),
+                  onTap: () =>
+                      context.pushNamed(Paths.resetPasswordRequest.name),
                 ),
               ),
             ],

--- a/lib/features/profile/profile_mobile_layout.dart
+++ b/lib/features/profile/profile_mobile_layout.dart
@@ -47,7 +47,7 @@ class ProfileMobileLayout extends ConsumerWidget {
                   ),
                   child: GestureDetector(
                     child: Icon(PhosphorIcons.gear()),
-                    onTap: () => context.push(Paths.settings.route),
+                    onTap: () => context.pushNamed(Paths.settings.name),
                   ),
                 ),
               ),
@@ -77,8 +77,8 @@ class ProfileMobileLayout extends ConsumerWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   GestureDetector(
-                    onTap: () => context.push(
-                      Paths.friends.route,
+                    onTap: () => context.pushNamed(
+                      Paths.friends.name,
                       extra: FriendsViewModel(
                         friendType: FriendType.followers,
                         uid: data.user?.uid ?? '',
@@ -107,8 +107,8 @@ class ProfileMobileLayout extends ConsumerWidget {
                     ),
                   ),
                   GestureDetector(
-                    onTap: () => context.push(
-                      Paths.friends.route,
+                    onTap: () => context.pushNamed(
+                      Paths.friends.name,
                       extra: FriendsViewModel(
                         friendType: FriendType.following,
                         uid: data.user?.uid ?? '',

--- a/lib/features/profile/profile_notifier.dart
+++ b/lib/features/profile/profile_notifier.dart
@@ -76,6 +76,7 @@ class ProfileAsyncNotifier extends AsyncNotifier<ProfileState> {
         ProfileState(
           status: ProfileStatus.success,
           user: user,
+          isCurrentUser: isCurrentUser,
           stories: stories.content,
           friend: friendRequest,
           followers: followersResult.when((value) => value, (_, __) => 0),

--- a/lib/features/settings/settings_mobile_layout.dart
+++ b/lib/features/settings/settings_mobile_layout.dart
@@ -21,13 +21,13 @@ class SettingsMobileLayout extends ConsumerWidget {
         SettingsTile(
           icon: PhosphorIcons.userGear(),
           text: l10n.user_settings,
-          onTap: () => context.push(Paths.editProfile.route),
+          onTap: () => context.pushNamed(Paths.editProfile.name),
         ),
         const Divider(),
         SettingsTile(
           icon: PhosphorIcons.translate(),
           text: l10n.change_language,
-          onTap: () => context.push(Paths.changeLanguage.route),
+          onTap: () => context.pushNamed(Paths.changeLanguage.name),
         ),
         const Spacer(),
         GestureDetector(


### PR DESCRIPTION
Fixes #51 #52

- Update navigation to use named routes for consistency.
- Now profile notifier checks if is current user.

Coded-by: @migcarde