### PR TITLE
fix(feed_notifier): Feed - Stories multiplied

### DIFF
--- a/lib/features/feed/feed_mobile_layout.dart
+++ b/lib/features/feed/feed_mobile_layout.dart
@@ -24,7 +24,9 @@ class _FeedMobileLayoutState extends ConsumerState<FeedMobileLayout> {
     super.initState();
 
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      ref.read(feedNotifierProvider.notifier).init();
+      if (ref.read(feedNotifierProvider).status == FeedNotifierStatus.loading) {
+        ref.read(feedNotifierProvider.notifier).init();
+      }
     });
   }
 

--- a/lib/features/feed/feed_notifier.dart
+++ b/lib/features/feed/feed_notifier.dart
@@ -11,7 +11,7 @@ class FeedNotifier extends StateNotifier<FeedNotifierState> {
   final StoriesRepository storiesRepository;
 
   Future<void> init() async {
-    state = state.copyWith(status: FeedNotifierStatus.loading);
+    state = state.copyWith(status: FeedNotifierStatus.loading, stories: []);
     if (authNotifier.user?.uid.isNotEmpty == true) {
       await _getStories();
     }


### PR DESCRIPTION
Fixes #66

- Ensure stories are initialized as empty on loading status.

Coded-by: @migcarde