### PR TITLE
fix(comment): Comment too large disaligned

### DIFF
--- a/lib/comment_tile/comment_row.dart
+++ b/lib/comment_tile/comment_row.dart
@@ -56,7 +56,7 @@ class CommentRow extends ConsumerWidget {
                       maxLines: 5,
                       expandText: l10n.show_more,
                       collapseText: l10n.show_less,
-                      textAlign: TextAlign.center,
+                      textAlign: TextAlign.start,
                       animation: true,
                       style: theme.textTheme.bodySmall,
                       linkColor: theme.primaryColor,


### PR DESCRIPTION
Fixes #75

- Align text to start in comment row.

Coded-by: @migcarde