### PR TITLE
fix(navigation): On tap comment notification when app is terminated, the app does not goes to story screen

### DIFF
--- a/lib/routes/go_router_config.dart
+++ b/lib/routes/go_router_config.dart
@@ -37,24 +37,26 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       log.severe('GoRouter exception: ${state.uri}');
     },
     redirect: (context, state) {
-      final authState = ref.watch(authNotifierProvider);
+      final authState = ref.read(authNotifierProvider);
       final isConnected = ref.read(authNotifierProvider.notifier).user != null;
-      final isLoading = ref.watch(authNotifierProvider).isLoading;
+      final isLoading = ref.read(authNotifierProvider).isLoading;
       final isAllowed = allowedPaths.contains(state.fullPath?.lastUrlSegment);
 
-      if (authState.status.isPasswordRecovery) {
-        FlutterNativeSplash.remove();
-        return Paths.changePassword.route;
-      } else if (!isLoading && !isConnected && !isAllowed) {
-        FlutterNativeSplash.remove();
-        return Paths.login.route;
-      } else if (!isLoading &&
-          isConnected &&
-          (isAllowed || state.fullPath == '/')) {
-        FlutterNativeSplash.remove();
-        return Paths.home.route;
-      } else {
+      if (isLoading) {
         return null;
+      } else {
+        FlutterNativeSplash.remove();
+
+        if (authState.status.isPasswordRecovery) {
+          return Paths.changePassword.route;
+        } else if (!isConnected && !isAllowed) {
+          return Paths.login.route;
+        } else if (isConnected && (isAllowed || state.fullPath == '/')) {
+          FlutterNativeSplash.remove();
+          return Paths.home.route;
+        } else {
+          return null;
+        }
       }
     },
   );

--- a/lib/services/messaging/messaging_notifier.dart
+++ b/lib/services/messaging/messaging_notifier.dart
@@ -60,6 +60,11 @@ class MessagingNotifier extends AsyncNotifier<void>
       alert: true,
     );
 
+    final initialMessage = await FirebaseMessaging.instance.getInitialMessage();
+    if (initialMessage != null) {
+      await _onTapBackgroundMessage(initialMessage);
+    }
+
     FirebaseMessaging.onMessage.listen(_onRecieveForegroundMessage);
     FirebaseMessaging.onBackgroundMessage(_onReceiveBackgroundMessage);
     FirebaseMessaging.onMessageOpenedApp.listen(


### PR DESCRIPTION
Fixes #89

- Refactor GoRouter redirect logic and improve splash screen handling.
- Handle initial message when app is opened from a terminated state.

Coded-by: @migcarde